### PR TITLE
Convert to a ready-to-use standalone github pages template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,89 @@
-@yohanfernando blog ([view](http://yohanfernando.github.io/))
+Template of my blog ([view](http://yohanfernando.github.io/))
 ==================
 
 
 ## About
 
-This is the git repository for my personal blog hosted via GitHub Pages.  
+This is the template of my blog with my details stripped off and ready to 
+use/serve as a template for your Jekyll based GitHub pages site*.
 
-I am creating this blog using Jekyll and planning to release a post on completion detailing the 
-steps I went through which may help someone in future.  
+**Preview template: [http://yohanfernando.github.io/yohanfernando.github-pages.template/]
+(http://yohanfernando.github.io/yohanfernando.github-pages.template/)**
+ 
+\* Require very minimal modifications and may take max 15-20 minutes if you have all 
+the images ready.
 
-### What did I do so far…
+## How to use
+
+If you wish to use this template in your own site please follow the following steps.  
+
+**First and foremost check out the latest version from my `gh-pages` branch.** 
+
+Here onwards the workflow differs based on the type of site you create, follow appropriate 
+instructions to get you set up quickly as possible.
+ 
+#### a. User / Organisation GitHub Pages Site
+
+1. Rename the `gh-pages` branch to be `master` as github pages user/organisation sites 
+only get served from the `master` branch
+
+2. Open `_config.yml` file and add your details and site/url specific details to all the places 
+where I have noted as `AMEND_HERE`. 
+
+3. Set the value for `baseurl:` as an empty string (`baseurl: ""`) in `_config.yml` file.  
+
+4. Now go to **"Edit Demo Content & Go Live"** section  
+
+
+#### b. Project GitHub Pages Site
+
+1. Project pages are served from the `gh-pages` branch, so its essential that you keep the same
+branch name.
+
+2. Open `_config.yml` file and add your details and site/url specific details to all the places 
+where I have noted as `AMEND_HERE`. 
+
+3. Set the value for `baseurl:` as your repository name starting with a "`/`" 
+(e.g.- `baseurl: "/yohanfernando.github-pages.template"`) in `_config.yml` file.  
+
+4. Now go to **"Edit Demo Content & Go Live"** section  
+
+
+#### Edit Demo Content & Go Live
+
+1. Add header & author thumbnail images  
+    a. add the image you selected for your header background image to the `assets/images` folder    
+    b. add the author thumbnails (picture of you / your persona) to the `assets/images` folder.   
+    Thumbnails should be in three sizes, 400px x 400px, 300px x 300px and 200px x 200px.    
+    c. open `_scss/variables.scss`  
+    d. add the relative url (or the full url if hosted externally) of the image you selected for
+      your header background image to the `$header-background-image` variable 
+      (e.g. "`/assets/images/header.jpg`"), NB relative url should start with a "`/`" for 
+      user/organisation sites, and with "`/your-repo-name/`" for project pages sites.      
+    e. similarly add urls of the author thumbnails. The 400px x 400px should be added 
+    to `$site-owner-thumb-lg`, 300px x 300px should be added to `$site-owner-thumb-md` 
+    and 200px x 200px should be added to `$site-owner-thumb-sm variables`.   
+    f. if you wish to you can amend remaining variables (optional)  
+    
+2. Edit the about.md with your details, when adding content make sure to either;  
+    a. add an "excerpt" as the front matter  
+    b. or add the site excerpt_separator from where you want post to be cut off in the home page
+     (excerpt_separator is "`<!-- more -->`")
+
+3. Delete all the dummy posts form the "`_posts`" folder and I recommend adding 2-3 posts to start 
+with (optional to add).
+
+4. Edit the README.md file and add your own description 
+ 
+5. Set the `git origin` with your repository details and push changes to the `origin`.
+  
+6. Wola, your site is now LIVE :)
+
+7. Send me a message or a tweet ([@yohanfernando](http://twitter.com/yohanfernando)) to say you 
+used my template - just to put a smile on my face and as a reward for my hard work :).
+
+ 
+## How I developed the template
 
 #### Phase 1 - Setup Jekyll base blog
 
@@ -86,7 +160,8 @@ output folder ('_site') or rebuild the whole site.
 * First install following npm plugins to assist with the gulp setup  
 
     ```js
-        npm install --save-dev gulp gulp-autoprefixer gulp-notify gulp-rename gulp-sass browser-sync  
+        npm install --save-dev gulp gulp-autoprefixer gulp-rename gulp-sass 
+        gulp-open gulp-wait browser-sync  
     ```  
 
 * As I am going to be using Zurb's Foundation framework in the project, install that using 

--- a/_config.yml
+++ b/_config.yml
@@ -1,28 +1,32 @@
+# ---------------------------------------------------------------
 # Site settings
-title:    Blog title
-baseurl: ""
+# ---------------------------------------------------------------
 
+# AMEND_HERE >>> site.title will appear as the html head title
+title: Site title
+
+# AMEND_HERE >>> base url need to be defined if used as a website for a project, simply add the
+# name of your repository. If used as a user/organisation page this should be empty.
+baseurl: "/yohanfernando.github-pages.template"
+# For User/Organisation pages use empty baseurl
+# baseurl: ""
+
+# AMEND_HERE >>> This description will appear in the footer of your site
 description: > #
  You can add a description to this section to explain the blog or your self.
 
+# AMEND_HERE >>> Site owner details
 site_owner: Your Name
+site_owner_email: youremail@domain.com
 site_strapline: a cool strap line for the site
-site_owner_email:    youremail@domain.com
-url: "http://your-github-repo.github.io" # the base hostname & protocol for your site
 
+# AMEND_HERE >>> url of your site (where index.html) can be seen
+url: "http://your-github-repo.github.io/yohanfernando.github-pages.template"
 
-# Social media details
+# AMEND_HERE >>> Add your social media details
 twitter_username: twitter_handle
 github_username:  github_handle
 
-
-# Build settings
-markdown: kramdown
-
-permalink:  /blog/:title/
-paginate:   4
-
-excerpt_separator: <!-- more -->
 
 defaults:
   -
@@ -30,7 +34,26 @@ defaults:
       path: ""
     values:
       layout: "post"
-      author: "Your Name"
+      # AMEND_HERE >>> Add your name as the author
+      author: "Your name"
+
+
+# AMEND the _SCSS / variables >>>
+# GO TO '_SCSS' folder and open variables.scss to customise the template's
+# header background image, site owner thumbnail image (picture of your face/persona need to be
+# added in three sizes), font, font colours etc (more customisations will be added).
+
+
+# ---------------------------------------------------------------
+# Build settings - not to be edited
+# ---------------------------------------------------------------
+
+markdown: kramdown
+
+permalink:  /blog/:title/
+paginate:   4
+
+excerpt_separator: <!-- more -->
 
 exclude: ['LICENSE.md','README.md','GemFile','Gemfile.lock',
           'package.json', 'bower.json','gulpfile.js',

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
 <div class="row">
     <div class="small-12 small-centered medium-6 medium-centered columns text-center">
-        <a href="/blog/" class="read-all-articles-button">View all Articles</a>
+        <a href="{{ '/blog/' | prepend: site.baseurl }}" class="read-all-articles-button">View all Articles</a>
     </div>
 </div>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,7 +7,10 @@
     <meta name="description" content="{{ site.description }}">
     <!-- todo: more meta -->
 
-    <link rel="stylesheet" href="assets/css/style.css">
+    <link rel="stylesheet" href="{{ '/assets/css/style.css' | prepend: site.baseurl }}">
+    <link rel="canonical"
+          href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
+
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700' rel='stylesheet'
           type='text/css'>
 </head>

--- a/_includes/header-compact.html
+++ b/_includes/header-compact.html
@@ -2,7 +2,7 @@
     <div class="darken"></div>
     <div class="row">
         <div class="small-12 column">
-            <a href="/">
+            <a href="{{ '/' | prepend: site.baseurl }}">
                 <div class="row">
                     <div class="show-for-small-only small-2 small-centered columns author-portrait-circle-lg">
                     </div>
@@ -10,13 +10,13 @@
             </a>
 
             <div class="row">
-                <a href="/">
+                <a href="{{ '/' | prepend: site.baseurl }}">
                     <div class="show-for-medium-up medium-1 columns author-portrait-circle-md">
                     </div>
                 </a>
 
                 <div class="medium-10 end columns small-text-center medium-text-left">
-                    <a href="/">
+                    <a href="{{ '/' | prepend: site.baseurl }}">
                         <h2>{{ site.site_owner }}</h2>
                     </a>
 
@@ -24,7 +24,7 @@
                         <small>{{ site.site_strapline }}</small>
                     </h3>
                     <h5>
-                        <a href="/about">about</a>
+                        <a href="{{ '/about' | prepend: site.baseurl }}">about</a>
                         | <a href="#">cv</a>
                         <span class="show-social-icons-inline">
                             |

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,14 +3,14 @@
     <div class="row">
         <div class="small-12 column">
             <div class="row">
-                <a href="/">
+                <a href="{{ '/' | prepend: site.baseurl }}">
                     <div class="small-2 small-centered column author-portrait-circle-lg">
                     </div>
                 </a>
             </div>
             <div class="row">
                 <div class="small-12 small-centered column">
-                    <a href="/">
+                    <a href="{{ '/' | prepend: site.baseurl }}">
                         <h2>{{ site.site_owner }}</h2>
                     </a>
 
@@ -18,7 +18,7 @@
                         <small>{{ site.site_strapline }}</small>
                     </h3>
 
-                    <h5><a href="/about">about</a> | <a href="#">cv</a></h5>
+                    <h5><a href="{{ '/about' | prepend: site.baseurl }}">about</a> | <a href="#">cv</a></h5>
                 </div>
             </div>
         </div>

--- a/_scss/template/_header.scss
+++ b/_scss/template/_header.scss
@@ -5,7 +5,7 @@
 */
 
 .header {
-  background: url('https://static.pexels.com/photos/6894/summer-photographer-pier-adventure-large.jpg') no-repeat center center;
+  background: url($header-background-image) no-repeat center center;
   background-size: cover;
   color: $white;
   overflow: hidden;
@@ -86,7 +86,7 @@
 }
 
 .author-portrait-circle-lg {
-  background: url("http://placehold.it/400x400&text=[FACE]") no-repeat center center;
+  background: url($site-owner-thumb-lg) no-repeat center center;
   -moz-border-radius: 3em;
   border-radius: 3em;
   height: 6em;
@@ -94,7 +94,7 @@
 }
 
 .author-portrait-circle-md {
-  background: url("http://placehold.it/400x400&text=[FACE]") no-repeat center center;
+  background: url($site-owner-thumb-md) no-repeat center center;
   -moz-border-radius: 2em;
   border-radius: 2em;
   height: 4em;
@@ -102,7 +102,7 @@
 }
 
 .author-portrait-circle-sm {
-  background: url("http://placehold.it/400x400&text=[FACE]") no-repeat center center;
+  background: url($site-owner-thumb-sm) no-repeat center center;
   -moz-border-radius: 1em;
   border-radius: 1em;
   height: 2em;

--- a/_scss/variables.scss
+++ b/_scss/variables.scss
@@ -5,7 +5,18 @@
   desired visual look & feel.
 */
 
-//font-family:
+// AMEND_HERE >>>
+// Set a background image of your preference, lager the better to cover big screens
+$header-background-image: 'https://static.pexels.com/photos/6894/summer-photographer-pier-adventure-large.jpg';
+
+// AMEND_HERE >>>
+// Set site owner/author thumbnail image (picture of your face/persona)
+// The thumbnail needs to be on three sizes as below
+$site-owner-thumb-lg: 'http://placehold.it/400x400&text=[FACE]';
+$site-owner-thumb-md: 'http://placehold.it/300x300&text=[FACE]';
+$site-owner-thumb-sm: 'http://placehold.it/200x200&text=[FACE]';
+
+//Set font-family:
 $body-font-family: 'Open Sans', sans-serif;
 
 //set customisation colours

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -4,9 +4,6 @@
 
   This would import all the related partials to compile the css file for the site.
 */
-/*!
- *  hi there 中文注释 a
- */
 /*! normalize.css v3.0.3 | MIT License | github.com/necolas/normalize.css */
 /**
  * 1. Set default font family to sans-serif.
@@ -374,8 +371,8 @@ th {
 /*
   Copyright 2015, Yohan Fernando (@yohanfernando)
 
-  This contains all the variables I have used in the site which you can alter to get the desired visual
-  look & feel.
+  This contains all the variables I have used in the site which you can alter to get the
+  desired visual look & feel.
 */
 meta.foundation-version {
   font-family: "/5.5.2/"; }
@@ -8916,16 +8913,6 @@ th.hide-for-touch {
 /*
   Copyright 2015, Yohan Fernando (@yohanfernando)
 
-  This contains all the scss variables used in the template.
-*/
-/*
-  Copyright 2015, Yohan Fernando (@yohanfernando)
-
-  This contains all the scss customisations to the footer section.
-*/
-/*
-  Copyright 2015, Yohan Fernando (@yohanfernando)
-
   This contains all the scss customisations to the header section.
 */
 .header {
@@ -8990,13 +8977,13 @@ th.hide-for-touch {
   width: 6em; }
 
 .author-portrait-circle-md {
-  background: url("http://placehold.it/400x400&text=[FACE]") no-repeat center center;
+  background: url("http://placehold.it/300x300&text=[FACE]") no-repeat center center;
   border-radius: 2em;
   height: 4em;
   width: 4em; }
 
 .author-portrait-circle-sm {
-  background: url("http://placehold.it/400x400&text=[FACE]") no-repeat center center;
+  background: url("http://placehold.it/200x200&text=[FACE]") no-repeat center center;
   border-radius: 1em;
   height: 2em;
   width: 2em; }

--- a/index.html
+++ b/index.html
@@ -32,7 +32,7 @@ layout: home
     <div class="small-12 large-4 large-offset-1 columns panel about-me">
         {% for p in site.html_pages %}
         {% if p.url == '/about/' %}
-        <a href="{{p.url}}" target="_blank">
+        <a href="{{ p.url | prepend: site.baseurl }}">
             <h3>{{ p.title }}</h3>
         </a>
 

--- a/package.json
+++ b/package.json
@@ -12,9 +12,10 @@
     "browser-sync": "^2.8.2",
     "gulp": "^3.9.0",
     "gulp-autoprefixer": "^2.3.1",
-    "gulp-notify": "^2.2.0",
+    "gulp-open": "^1.0.0",
     "gulp-rename": "^1.2.2",
-    "gulp-sass": "^2.0.4"
+    "gulp-sass": "^2.0.4",
+    "gulp-wait": "0.0.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Made amendments to the site across the board to be able to quickly
adapt the template to create other github pages site. Added instructions
to the _config.yml to specify which section need to be modified and
similarly added instructions to the variables.css file.

Edited whole site to have url's prepended with the baser so that links
will work as user/organisation site or even as a project site.

Edited the README.md file with instructions on how to adapt this as a
template for another users/projects GitHub pages site.

Closes issue #10
