### PR TITLE
Add corrective fix to show excerpt when separator is used

### DIFF
--- a/_includes/templates/share.html
+++ b/_includes/templates/share.html
@@ -9,8 +9,10 @@
 {% endif %}
 
 <!-- Set share text -->
-{% if include.post.content contains "<!-- more -->" %}
-{% assign share_text = include.post.excerpt | strip_html %}
+{% if include.post.excerpt %}
+{% assign share_text = include.post.excerpt | strip_html | truncatewords:30 %}
+{% elsif include.post.content contains "<!-- more -->" %}
+{{ include.post.content | split:'<!-- more -->' | first  | strip_html | truncatewords:30 }}
 {% elsif include.post.content %}
 {% assign share_text = include.post.content | strip_html | truncatewords:30 %}
 {% else %}

--- a/_includes/templates/sub_article.html
+++ b/_includes/templates/sub_article.html
@@ -14,8 +14,10 @@
 <div class="separator"></div>
 
 <p>
-    {% if include.subarticle.content contains "<!-- more -->" %}
-    {{ include.subarticle.excerpt | strip_html }}
+    {% if include.subarticle.excerpt %}
+    {{ include.subarticle.excerpt }}
+    {% elsif include.subarticle.content contains "<!-- more -->" %}
+    {{ include.subarticle.content | split:'<!-- more -->' | first }}
     {% else %}
     {{ include.subarticle.content | strip_html | truncatewords:30 }}
     {% endif %}

--- a/_scss/template/_content.scss
+++ b/_scss/template/_content.scss
@@ -58,6 +58,10 @@
     color: $primary-color;
   }
 
+  .read-about-me {
+    margin-top: 1em;
+  }
+
 }
 
 .share-posts {

--- a/index.html
+++ b/index.html
@@ -37,11 +37,17 @@ layout: home
         </a>
 
         <div class="separator"></div>
-        {% if p.content contains "<!-- more -->" %}
-        {{ p.excerpt | strip_html }}
+        {% if p.excerpt %}
+        {{ p.excerpt }}
+        {% elsif p.content contains "<!-- more -->" %}
+        {{ p.content | split:'<!-- more -->' | first }}
         {% else %}
         {{ p.content | strip_html | truncatewords:100 }}
         {% endif %}
+
+        <p class="read-about-me">
+            <a href="{{ p.url | prepend: site.baseurl }}">Read more...</a>
+        </p>
         {% endif %}
         {% endfor %}
     </div>


### PR DESCRIPTION
The excerpt didn't show up as expected when the excerpt_separator is
used. Hence added a feature to extract it from post content.

Also added a read more link to about me snippet.

Resolves #14
